### PR TITLE
Dockerfile ease of use updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14.0-alpine as build
+FROM node:16.14.0-alpine AS build
 WORKDIR /app
 ENV PATH /app/node_modules/.bin:$PATH
 COPY package.json ./


### PR DESCRIPTION
There are two simple items in this PR to provide a better experience from the Docker build. 

1. Add the EXPOSE command to advertise the used port of 3000. This allows it to be easily discovered by other services like Traefik and also shows in the docker reporting like ps. No functionality change, just and ease of use item.
2.  Fix the case of the as command so that it matches the corresponding FROM command. This will clean up a warning in the build that they do not match.