### PR TITLE
Create a mutipart build to condense the docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# Step 1: Create the build artifacts
 FROM node:16.14.0-alpine AS build
 WORKDIR /app
 ENV PATH /app/node_modules/.bin:$PATH
@@ -5,7 +6,7 @@ COPY package.json ./
 COPY package-lock.json ./
 RUN npm ci --silent
 RUN npm install react-scripts@3.4.1 -g --silent
-RUN npm install serve -g --silent
+
 COPY . ./
 
 ARG HOST_ENV
@@ -34,9 +35,16 @@ ENV REACT_APP_HOSTNAME_PARTS=$HOSTNAME_PARTS
 
 ARG REACT_APP_SOCIAL_META=$SOCIAL_META
 
-EXPOSE 3000
 
 RUN npm run build
 
-# start the nginx web server
+# Step 2: Create the compact production image
+FROM node:16.14.0-alpine AS production
+WORKDIR /app
+COPY --from=build /app/build ./build
+RUN npm install serve -g --silent
+
+EXPOSE 3000
+
+# start the web server
 CMD ["serve", "-s", "/app/build"]


### PR DESCRIPTION
Addresses Issue #41

* Removed the installation of the serve library from the build step since it is not required.
* Add a new step to create a minumal node image and copy the build artifacts from step one into it.
* Add step to install serve into the final compact image.
* All the build dependencies are not required in the final image which reduces the size significantly.
* New build size is ~130M instead of ~1.8G. Further reduction of half could be obtained by using nginx instead of node to serve the content.