### PR TITLE
Removes sponsorship sections

### DIFF
--- a/src/views/pages/controlPanel/dashboard/index.jsx
+++ b/src/views/pages/controlPanel/dashboard/index.jsx
@@ -14,7 +14,6 @@ const Dashboard = () => {
   return (
     <Box sx={{ mt: 2 }}>
       <Grid container spacing={gridSpacing}>
-        <DashboardSponsor />
         <DashboardHeader />
         <DashboardCharts />
       </Grid>

--- a/src/views/pages/controlPanel/viewerSettings/index.jsx
+++ b/src/views/pages/controlPanel/viewerSettings/index.jsx
@@ -55,7 +55,6 @@ const ViewerSettings = () => {
   return (
     <Box sx={{ mt: 2 }}>
       <Grid container spacing={gridSpacing}>
-        <SettingsSponsor />
         <Grid item xs={12}>
           <MainCard title="Remote Falcon Settings" content={false}>
             <Grid container spacing={gridSpacing}>


### PR DESCRIPTION
Removes the sponsorship sections from the dashboard and viewer settings pages.

This change is due to the conclusion of the sponsorship agreement.