### PR TITLE
Refactors feature flag handling

### DIFF
--- a/src/layout/MainLayout/Sidebar/MenuList/NavGroup/index.jsx
+++ b/src/layout/MainLayout/Sidebar/MenuList/NavGroup/index.jsx
@@ -6,13 +6,13 @@ import { useSelector } from '../../../../../store';
 
 import NavCollapse from '../NavCollapse';
 import NavItem from '../NavItem';
-import {useFeatureFlagPayload} from "posthog-js/react";
+import { useIsFeatureFlagEnabled } from '../../../../../utils/featureFlags';
 
 const NavGroup = ({ item }) => {
   const theme = useTheme();
   const { show } = useSelector((state) => state.show);
 
-  const askWattsonPayload = useFeatureFlagPayload('ask-wattson');
+  const isAskWattsonEnabled = useIsFeatureFlagEnabled('ask-wattson', show?.showSubdomain);
 
   // menu list collapse & items
   const items = item.children?.map((menu) => {
@@ -21,7 +21,7 @@ const NavGroup = ({ item }) => {
         return <></>;
       }
     }
-    if (menu.id === 'ask-wattson' && !askWattsonPayload?.includes(show?.showSubdomain)) {
+    if (menu.id === 'ask-wattson' && !isAskWattsonEnabled) {
       return <></>;
     }
     switch (menu.type) {

--- a/src/utils/featureFlags.jsx
+++ b/src/utils/featureFlags.jsx
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+import { useFeatureFlagEnabled, usePostHog } from 'posthog-js/react';
+
+/**
+ * Hook: useIsFeatureFlagEnabled
+ * Evaluates a PostHog feature flag for the current user/session.
+ *
+ * NOTE: The PostHog browser SDK evaluates flags for the currently identified user only.
+ * We accept an optional distinctId parameter to satisfy the desired API, but we do not
+ * auto-identify as that would mutate global analytics identity. If your app identifies
+ * users elsewhere, ensure PostHog has the correct distinct_id before using this hook.
+ */
+export function useIsFeatureFlagEnabled(flagName, distinctId) {
+  const posthog = usePostHog?.();
+
+  // We intentionally avoid calling posthog.identify(distinctId) here to prevent side effects.
+  // This effect is just a placeholder for future extension if needed.
+  useEffect(() => {
+    if (!posthog) return;
+    // If you ever want to identify here (not recommended automatically),
+    // ensure you handle restoring previous identity and related side effects.
+    // const current = posthog.get_distinct_id?.();
+    // if (distinctId && current && current !== distinctId) {}
+  }, [posthog, distinctId]);
+
+  try {
+    const enabled = useFeatureFlagEnabled(flagName);
+    return Boolean(enabled);
+  } catch (_) {
+    return false;
+  }
+}
+
+export default useIsFeatureFlagEnabled;

--- a/src/views/pages/controlPanel/askWattson/index.jsx
+++ b/src/views/pages/controlPanel/askWattson/index.jsx
@@ -7,8 +7,8 @@ import {gridSpacing} from "../../../../store/constant";
 import {Box, Grid} from "@mui/material";
 import { ReactMarkdown } from 'react-markdown/lib/react-markdown';
 import remarkBreaks from "remark-breaks";
-import {useFeatureFlagPayload} from "posthog-js/react";
 import mixpanel from "mixpanel-browser";
+import useIsFeatureFlagEnabled from "../../../../utils/featureFlags";
 
 // Storage key for chat history
 const STORAGE_KEY = 'wattson_chat_history';
@@ -19,7 +19,7 @@ const AskWattson = () => {
   const dispatch = useDispatch();
   const { show } = useSelector((state) => state.show);
 
-  const askWattsonPayload = useFeatureFlagPayload('ask-wattson');
+  const isAskWattsonEnabled = useIsFeatureFlagEnabled('ask-wattson', show?.showSubdomain);
 
   // Storage key (no user-specific partitioning)
   const getUserStorageKey = () => STORAGE_KEY;
@@ -196,7 +196,7 @@ const AskWattson = () => {
 
   return (
     <Box sx={{ mt: 0, height: 'calc(100vh - 130px)', overflow: 'hidden' }}>
-      {askWattsonPayload?.includes(show?.showSubdomain) ? (
+      {isAskWattsonEnabled ? (
         <Grid container spacing={gridSpacing} sx={{ height: '100%', overflow: 'hidden' }}>
           <Grid item xs={12} sx={{ height: '100%', overflow: 'hidden' }}>
             <div className="wattson-chat">


### PR DESCRIPTION
Introduces a custom hook for managing feature flags. This simplifies the logic for checking feature flag status and improves code reusability. Replaces direct calls to PostHog's `useFeatureFlagPayload` with the new `useIsFeatureFlagEnabled` hook.
