### PR TITLE
fix: stop dashboardLiveStats triple-fire and purgeStats auto-fire on dashboard mount

### DIFF
--- a/src/views/pages/controlPanel/dashboard/DashboardCharts.jsx
+++ b/src/views/pages/controlPanel/dashboard/DashboardCharts.jsx
@@ -16,7 +16,7 @@ import RFLoadingButton from '../../../../ui-component/RFLoadingButton';
 import { ViewerControlMode } from '../../../../utils/enum';
 import { DASHBOARD_STATS } from '../../../../utils/graphql/controlPanel/queries';
 
-import { DELETE_STATS_WITHIN_RANGE, PURGE_STATS } from '../../../../utils/graphql/controlPanel/mutations';
+import { DELETE_STATS_WITHIN_RANGE } from '../../../../utils/graphql/controlPanel/mutations';
 import { showAlert } from '../../globalPageHelpers';
 import ApexBarChart from './ApexBarChart';
 import ApexLineChart from './ApexLineChart';
@@ -46,7 +46,6 @@ const DashboardCharts = () => {
   const datePlus1 = new Date();
   datePlus1.setHours(0, 0, 0);
 
-  const [purgeStatsMutation] = useMutation(PURGE_STATS);
   const [deleteStatsWithinRangeMutation] = useMutation(DELETE_STATS_WITHIN_RANGE);
 
   const [dashboardStatsQuery] = useLazyQuery(DASHBOARD_STATS);
@@ -119,10 +118,6 @@ const DashboardCharts = () => {
     };
     init();
   }, [fetchDashboardStats]);
-
-  useEffect(() => {
-    purgeStatsMutation();
-  }, [purgeStatsMutation]);
 
   return (
     <>

--- a/src/views/pages/controlPanel/dashboard/DashboardHeader.jsx
+++ b/src/views/pages/controlPanel/dashboard/DashboardHeader.jsx
@@ -59,13 +59,11 @@ const DashboardHeader = () => {
   }, [dashboardLiveStatsQuery, dispatch, show?.timezone]);
 
   useEffect(() => {
-    const init = async () => {
-      setIsLoading(true);
-      await fetchDashboardLiveStats();
-      setIsLoading(false);
-    };
-    init();
-  }, [fetchDashboardLiveStats]);
+    if (!show?.timezone) return;
+    setIsLoading(true);
+    fetchDashboardLiveStats().finally(() => setIsLoading(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [show?.timezone]);
 
   useInterval(async () => {
     await fetchDashboardLiveStats();


### PR DESCRIPTION
## Summary

- Removes the `useEffect` that auto-fired the `purgeStats` mutation on every dashboard mount. The 18-month retention is intentional and matches the published "we don't store data longer than 18 months" policy — but the dashboard read path is the wrong place to enforce it (per-load redundant writes, no coverage for inactive shows, 5s blocking the response). The backend `purgeStats` mutation resolver stays in place; backend-scheduled-job follow-up tracked separately.
- Fixes the `dashboardLiveStats` triple-fire. The previous `useEffect` re-ran whenever `fetchDashboardLiveStats`'s callback reference changed, which happens when `show?.timezone` arrives async from the redux store. Combined with the 5s `useInterval` polling, that produced 3 calls in the first ~10s of every dashboard load. Replaced with an effect gated on `show?.timezone` presence — fires once when timezone is known.

Together these eliminate 4 of 7 GraphQL calls on a populated-dashboard load (HAR-measured baseline: 7 calls totaling ~13.5s perceived for sign-in → dashboard rendered).

## Test plan

- [ ] Open dashboard in incognito with DevTools → Network tab → "Disable cache" + "Preserve log" checked.
- [ ] Sign in. Confirm exactly one `dashboardLiveStats` request fires on initial load (after `show?.timezone` arrives), then one every 5s from \`useInterval\`. No \`purgeStats\` request anywhere.
- [ ] Confirm \`getShow\` and \`dashboardStats\` still fire normally and dashboard charts render with populated data.
- [ ] Verify the live-stats card ("Active Requests"/"Active Votes") still updates every 5s.
- [ ] Capture a fresh HAR and confirm GraphQL request count drops from 7 → 3 on dashboard mount.