### PR TITLE
feat: add RF Page Builder to premium templates

### DIFF
--- a/src/views/pages/controlPanel/viewerPageTemplates/PremiumTemplates.jsx
+++ b/src/views/pages/controlPanel/viewerPageTemplates/PremiumTemplates.jsx
@@ -8,6 +8,11 @@ const PremiumTemplates = () => (
       <CardActions>
         <List>
           <ListItem disablePadding>
+            <ListItemButton component="a" href="https://www.rfpagebuilder.com/" target="_blank">
+              <ListItemText primary="RF Page Builder" sx={{ textDecoration: 'underline' }} />
+            </ListItemButton>
+          </ListItem>
+          <ListItem disablePadding>
             <ListItemButton component="a" href="https://strammade3d.com/collections/remote-falcon-backgrounds" target="_blank">
               <ListItemText primary="Strammade 3D" sx={{ textDecoration: 'underline' }} />
             </ListItemButton>


### PR DESCRIPTION
## Summary
- Adds RF Page Builder (https://www.rfpagebuilder.com/) as a new entry in the Premium Templates list on the Viewer Page Templates control-panel screen
- Placed above the existing Strammade 3D entry

## Test plan
- [ ] Run `npm run dev`, sign in, navigate to Viewer Page Templates, confirm both entries render and links open in a new tab