### PR TITLE
feat: codify replicas=2 to match live cluster state

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -82,7 +82,7 @@ jobs:
           Namespace: remote-falcon
           Application: remote-falcon-ui
           Env: prod
-          Replicas: 1
+          Replicas: 2
           Image: ${{ env.REGISTRY }}/${{ steps.repository_string.outputs.lowercase }}:${{ github.sha }}
           Requests.Memory: 64Mi
           Requests.CPU: 5m


### PR DESCRIPTION
The `remote-falcon-ui` Deployment is currently running with `replicas: 2` in the prod cluster, but `.github/workflows/build-and-release.yml` still substitutes `Replicas: 1` into `k8s/manifest.yml` at deploy time. The next push to `main` would silently scale the UI back down to a single pod. This change updates the workflow's templated `Replicas` value to `2` so the codified manifest matches live state and future deploys preserve current capacity. UI is a static React bundle served by nginx, so no HPA is needed — a fixed replica count is the right primitive. No change to `k8s/manifest.yml` itself; only the workflow's substitution variable.