### PR TITLE
feat: eliminate redundant getShow query on login

### DIFF
--- a/src/contexts/JWTContext.jsx
+++ b/src/contexts/JWTContext.jsx
@@ -148,32 +148,23 @@ export const JWTProvider = ({ children }) => {
       },
       onCompleted: (data) => {
         setSession(data?.signIn?.serviceToken);
-        getShowQuery({
-          context: {
-            headers: {
-              Route: 'Control-Panel'
-            }
-          },
-          onCompleted: (data) => {
-            const showData = { ...data?.getShow };
-            showData.timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-            dispatch(
-              startLoginAction({
-                ...showData
-              })
-            );
-            // Identify this user/show in PostHog using the showSubdomain as distinct_id
-            try {
-              if (posthog && showData?.showSubdomain) {
-                posthog.identify(showData.showSubdomain, {
-                  email: showData?.email,
-                  showName: showData?.showName,
-                  showRole: showData?.showRole
-                });
-              }
-            } catch (_) {}
+        const showData = { ...data?.signIn };
+        showData.timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        dispatch(
+          startLoginAction({
+            ...showData
+          })
+        );
+        // Identify this user/show in PostHog using the showSubdomain as distinct_id
+        try {
+          if (posthog && showData?.showSubdomain) {
+            posthog.identify(showData.showSubdomain, {
+              email: showData?.email,
+              showName: showData?.showName,
+              showRole: showData?.showRole
+            });
           }
-        });
+        } catch (_) {}
       },
       onError: (error) => {
         if (error?.message === StatusResponse.UNAUTHORIZED) {

--- a/src/utils/graphql/controlPanel/queries.jsx
+++ b/src/utils/graphql/controlPanel/queries.jsx
@@ -3,7 +3,112 @@ import { gql } from '@apollo/client';
 export const SIGN_IN = gql`
   query @api(name: controlPanel) {
     signIn {
+      showToken
+      email
+      showName
+      showSubdomain
+      emailVerified
+      createdDate
+      lastLoginDate
+      expireDate
+      pluginVersion
+      fppVersion
+      lastLoginIp
+      showRole
+      playingNow
+      playingNext
       serviceToken
+      apiAccess {
+        apiAccessActive
+      }
+      userProfile {
+        firstName
+        lastName
+        facebookUrl
+        youtubeUrl
+        lastTokenResetDate
+      }
+      preferences {
+        viewerControlEnabled
+        viewerPageViewOnly
+        viewerControlMode
+        resetVotes
+        jukeboxDepth
+        locationCheckMethod
+        showLatitude
+        showLongitude
+        allowedRadius
+        checkIfVoted
+        checkIfRequested
+        psaEnabled
+        psaFrequency
+        jukeboxRequestLimit
+        locationCode
+        hideSequenceCount
+        makeItSnow
+        managePsa
+        sequencesPlayed
+        pageTitle
+        pageIconUrl
+        showOnMap
+        selfHostedRedirectUrl
+        blockedViewerIps
+        notificationPreferences {
+          enableFppHeartbeat
+          fppHeartbeatIfControlEnabled
+          fppHeartbeatRenotifyAfterMinutes
+          fppHeartbeatLastNotification
+        }
+      }
+      sequences {
+        name
+        key
+        displayName
+        duration
+        visible
+        index
+        order
+        imageUrl
+        active
+        visibilityCount
+        type
+        group
+        category
+        artist
+      }
+      sequenceGroups {
+        name
+        visibilityCount
+      }
+      psaSequences {
+        name
+        order
+        lastPlayed
+      }
+      pages {
+        name
+        active
+        html
+      }
+      requests {
+        sequence {
+          name
+        }
+        position
+        ownerRequested
+      }
+      votes {
+        sequence {
+          name
+        }
+        votes
+        lastVoteTime
+        ownerVoted
+      }
+      activeViewers {
+        ipAddress
+        visitDateTime
+      }
     }
   }
 `;


### PR DESCRIPTION
## Summary
- Login was firing `signIn` then immediately `getShow` against the control-panel GraphQL API, doubling round-trip latency on every sign-in.
- The backend `signIn` resolver already returns a full `Show` document (`signIn: Show` in `query.graphqls`, with `serviceToken` injected via `show.setServiceToken(...)`); the wire query was only asking for `serviceToken`.
- Expanded `SIGN_IN` to request the same field set as `GET_SHOW`, and refactored `JWTContext.login`'s `onCompleted` to consume `data.signIn` directly. The follow-up `getShowQuery` call is removed from the login path.
- The `init()` warm-start path (existing token in localStorage on page load) is untouched and still uses `getShow`, since it has no Basic auth credentials to invoke `signIn` with.

## Test plan
- [ ] Sign in with valid credentials; confirm DevTools Network shows one GraphQL request to `signIn` and no follow-up `getShow` on the login path.
- [ ] Confirm Redux `state.show` matches what it was before the change (same fields populated).
- [ ] Confirm PostHog identify still fires with `showSubdomain`, `email`, `showName`, `showRole`.
- [ ] Reload the app with an existing valid session token; confirm the `init()` warm-start `getShow` call still works.
- [ ] Sign in with bad credentials, unverified email, and unknown email; confirm error toasts unchanged.